### PR TITLE
优化：增加收杆时的断线与跑鱼检测，防止无效点击

### DIFF
--- a/PartyFish.py
+++ b/PartyFish.py
@@ -6277,7 +6277,12 @@ def pressandreleasemousebutton():
     # 先检查是否需要处理加时
     with mss.mss() as temp_scr:
         if handle_jiashi_in_action(temp_scr):
-            return
+            return True
+
+        # [新增] 故障检测：检查是否断线或超时（回到待机状态）
+        if f1_mached(temp_scr) or f2_mached(temp_scr):
+            print("⚠️ [监测] 检测到异常，判定为断线或鱼跑了，本轮结束")
+            return False
 
     user32.mouse_event(0x02, 0, 0, 0, 0)
     jittered_down = add_jitter(leftclickdown)
@@ -6287,6 +6292,7 @@ def pressandreleasemousebutton():
     jittered_up = add_jitter(leftclickup)
     time.sleep(jittered_up)
     print_timing_info("放线", leftclickup, jittered_up)
+    return True
 
 
 def ensure_mouse_down():
@@ -7033,7 +7039,10 @@ def main():
                             current_times = times
                         if a <= current_times:
                             a += 1
-                            pressandreleasemousebutton()  # 执行点击循环直到识别到 star.png
+                            # 调用优化后的点击循环函数，如果返回False表示遇到异常需中断
+                            if not pressandreleasemousebutton():
+                                a = 0
+                                break
                         else:
                             a = 0
                             print("🎣 [提示] 达到最大拉杆次数，本轮结束")


### PR DESCRIPTION
**问题描述：**
原有逻辑在收杆时（pressandreleasemousebutton）会死板地执行完所有点击次数。如果中途断线或鱼跑了，脚本仍会继续点击，导致节奏混乱。

**修改内容：**
1. 在收杆动作中增加了状态检测：
- 检测是否出现 F1/F2 图标（回到待机状态）。
2. 一旦检测到上述异常，立即停止当前收杆循环。